### PR TITLE
feat: add template for dbml

### DIFF
--- a/packages/hapify-templates-dbml/.gitignore
+++ b/packages/hapify-templates-dbml/.gitignore
@@ -1,0 +1,37 @@
+# compiled output
+/dist
+/node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# Hapify generated files
+models.dbml

--- a/packages/hapify-templates-dbml/.hapifyrc.js
+++ b/packages/hapify-templates-dbml/.hapifyrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: 'Hapify DBML templates',
+  description: 'Generate the DBML schema',
+  templates: [
+    {
+      "path": "models.dbml",
+      "engine": "hpf",
+      "input": "all"
+    },
+  ],
+};

--- a/packages/hapify-templates-dbml/CHANGELOG.md
+++ b/packages/hapify-templates-dbml/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/hapify-templates-dbml/README.md
+++ b/packages/hapify-templates-dbml/README.md
@@ -1,0 +1,34 @@
+# Hapify - DBML Schema
+
+## Installation
+
+```sh
+npm install @tractr/hapify-templates-dbml --save-dev
+```
+
+## Usage
+
+In your `package.json`:
+
+```javascript
+{
+  "name": "my-library",
+  "version": "1.0.0",
+  "hapify": { "extends": ["@tractr/hapify-templates-dbml"] }
+}
+```
+
+If you would like to extend or modify these properties, create a `.hapifyrc.js`
+file in your projects root directory and export your desired modifications.
+
+```javascript
+module.exports = {
+  extends: ['hapify-templates-dbml'],
+};
+```
+
+Or you can create a `.hapifyrc.json` file in your projects root directory.
+
+```javascript
+{ "extends": [ '@tractr/hapify-templates-dbml' ] }
+```

--- a/packages/hapify-templates-dbml/hapify/models.dbml.hpf
+++ b/packages/hapify-templates-dbml/hapify/models.dbml.hpf
@@ -1,0 +1,89 @@
+<<for Models model>>
+ 
+//--------------------------
+// <<model capital>>
+Table <<model pascal>> {
+<<for model.fields not manyMany field>>
+  <<field snake>> <<=type(field, model)>> <<=attributes(field)>>
+<<endfor>>
+
+<<if model.fields unique>>
+  Indexes {
+    <<if2 model.fields unique>>
+    (<<=snakeNames(model.fields.unique).join(',')>>) [unique, name: '<<=snakeNames(model.fields.unique).join('_')>>']
+    <<else>>
+    <<=model.fields.unique[0].names.snake>> [unique]
+    <<endif>>
+  }
+<<endif>>
+}
+
+<<for model.fields manyMany field>>
+// Many-to-many for <<model pascal>>.<<field snake>>
+Table <<model pascal>>_<<field pascal>> {
+    id integer [pk, increment]
+    <<model snake>> <<=type(model.fields.primary)>> [ref: > <<model pascal>>.<<model.fields.primary snake>>]
+    <<field.model snake>> <<=type(field.model.fields.primary)>> [ref: > <<field.model pascal>>.<<field.model.fields.primary snake>>]
+}
+<<endfor>>
+
+
+<<for model.fields enum field>>
+Enum <<model snake>>_<<field snake>> {
+<<for field.enum e>>
+    <<e snake>>
+<<endfor>>
+}
+<<endfor>>
+
+<<endfor>>
+
+
+<<< 
+function type(field, model = null) {
+    switch(field.type) {
+        case 'string':
+            switch(field.subtype) {
+                case 'rich':
+                case 'text':
+                    return 'text';
+                default: return 'varchar';
+            }
+        case 'boolean': return 'integer';
+        case 'number':
+            switch(field.subtype) {
+                case 'float': return 'float';
+                default: return 'integer';
+            }
+        case 'enum': return `${model.names.snake}_${field.names.snake}`;
+        case 'datetime': return 'datetime';
+        case 'entity':
+            return field.subtype === 'manyMany' ? 
+                'manyMany' :
+                type(field.model.fields.primary);
+        default: 'varchar';
+    }
+}
+function attributes(field) {
+    output = [];
+    if (field.primary) {
+        output.push('pk');
+        if (field.subtype === 'integer') output.push('increment');
+    } else {
+        if (field.type === 'entity') {
+            output.push(`ref: > ${field.model.names.pascal}.${field.model.fields.primary.names.snake}`);
+            if (field.subtype === 'oneOne') output.push('unique');
+        }
+        else if (!field.nullable) {
+            output.push('not null');
+            if (field.type === 'datetime' && field.internal) {
+                output.push('default: `now()`');
+            }
+        }
+    }
+    return output.length ? `[${output.join(', ')}]` : '';
+}
+function snakeNames(fields) {
+    return fields.map(f => f.names.snake);
+}
+>>>

--- a/packages/hapify-templates-dbml/index.js
+++ b/packages/hapify-templates-dbml/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./.hapifyrc.js');

--- a/packages/hapify-templates-dbml/package.json
+++ b/packages/hapify-templates-dbml/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@tractr/hapify-templates-dbml",
+  "version": "1.0.0",
+  "description": "Generate DBML schema",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tractr/stack"
+  },
+  "license": "UNLICENSED",
+  "author": "",
+  "main": "./index.js",
+  "files": [
+    "hapify",
+    ".hapifyrc.js",
+    "index.js"
+  ],
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "restricted",
+    "registry": "https://npm.pkg.github.com"
+  }
+}


### PR DESCRIPTION
@floross J'ai ajouté le template pour DBML.

Voici un exemple d'output: https://dbdiagram.io/d/605d3896ecb54e10c33d5146

Il prend en compte les relations oneMany, manyMany et oneOne.

Pour les relations manyMany il crée une table intermédiaire.

Pour les relations oneOne, je n'ai pas trouvé comment définir la cardinalité. J'ai mis un attribut `unique` sur la relation, mais ça ne définit pas la cardinalité correctement dans DbDiagram.io.

Il créé les indexes uniques pour les champs `unique`.
Il ne fait pas d'index pour les champs recherchables ou triables. Est-ce nécessaire pour l'utilisation que l'on fera du schéma DBML ?

Il gère les enums.

Il gère dynamiquement le type et le nom des clé primaire. Par exemple, dans le liens ci-dessus, il y a un modèle `Product` dont la clé primaire est `sku` de type `string`.

Dans DBML on peut mettre des notes au niveau du champs ou de la table, mais Hapify ne donne pas accès à cela dans le template .... 😁
