### PR TITLE
fix: api controllers async removal

### DIFF
--- a/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
+++ b/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
@@ -51,7 +51,6 @@ export class <<Model pascal>>Controller {
     return this.<<Model camel>>Service.create(formatedParams);
   }
  
-<<<<<<< HEAD
   /**
   * Count the number of <<Model pascal>> entities that matches the filter
   *
@@ -64,8 +63,6 @@ export class <<Model pascal>>Controller {
     return this.<<Model camel>>Service.count(formatedParams);
   }
  
-=======
->>>>>>> style: put back spaces on empty lines
   /**
    * Find zero or one <<Model pascal>> that matches the filter
    *
@@ -103,21 +100,6 @@ export class <<Model pascal>>Controller {
     return this.<<Model camel>>Service.findMany(formatedParams);
   }
  
-<<<<<<< HEAD
-=======
-  /**
-   * Count the number of <<Model pascal>> entities that matches the filter
-   *
-   * @param queryDto - Dto of the request query
-   * @returns the number of <<Model pascal>>
-   */
-  @Get('count')
-  public count(@Query() queryDto: <<Model pascal>>CountQueryDto): Promise<number> {
-    const formatedParams = this.<<Model camel>>RestDtoService.formatCountDto(queryDto);
-    return this.<<Model camel>>Service.count(formatedParams);
-  }
- 
->>>>>>> style: put back spaces on empty lines
   /**
    * Update one <<Model pascal>>
    *

--- a/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
+++ b/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
@@ -46,7 +46,7 @@ export class <<Model pascal>>Controller {
    * @returns a new User
    */
   @Post()
-  public create(@Body() bodyDto: <<Model pascal>>CreateBodyDto): Promise<<<Model pascal>>> {
+  public create(@Body() bodyDto: <<Model pascal>>CreateBodyDto) {
     const formatedParams = this.<<Model camel>>RestDtoService.formatCreateDto(bodyDto);
     return this.<<Model camel>>Service.create(formatedParams);
   }
@@ -76,7 +76,7 @@ export class <<Model pascal>>Controller {
     <<<if (root.dependencies.list.length || root.referencedIn.length) {>>>
     @Query() queryDto: <<Model pascal>>FindUniqueQueryDto,
     <<<}>>>
-  ): Promise<<<Model pascal>> | null> {
+  ) {
     const formatedParams = this.<<Model camel>>RestDtoService.formatFindUniqueDtos(
       paramsDto,
     <<<if (root.dependencies.list.length || root.referencedIn.length) {>>>
@@ -95,7 +95,7 @@ export class <<Model pascal>>Controller {
   @Get()
   public findMany(
     @Query() queryDto: <<Model pascal>>FindManyQueryDto,
-  ): Promise<<<Model pascal>>[]> {
+  ) {
     const formatedParams = this.<<Model camel>>RestDtoService.formatFindManyDto(queryDto);
     return this.<<Model camel>>Service.findMany(formatedParams);
   }
@@ -115,7 +115,7 @@ export class <<Model pascal>>Controller {
   public update(
     @Param() paramsDto: <<Model pascal>>UpdateParamsDto,
     @Body() bodyDto: <<Model pascal>>UpdateBodyDto,
-  ): Promise<<<Model pascal>>> {
+  ) {
     const formatedParams = this.<<Model camel>>RestDtoService.formatUpdateDtos(
       paramsDto,
       bodyDto,
@@ -139,7 +139,7 @@ export class <<Model pascal>>Controller {
   public upsert(
     @Param() paramsDto: <<Model pascal>>UpsertParamsDto,
     @Body() bodyDto: <<Model pascal>>UpsertBodyDto,
-  ): Promise<<<Model pascal>>> {
+  ) {
     const formatedParams = this.<<Model camel>>RestDtoService.formatUpsertDtos(
       paramsDto,
       bodyDto,
@@ -154,7 +154,7 @@ export class <<Model pascal>>Controller {
    * @returns the updated <<Model pascal>>
    */
   @Delete(':id')
-  public delete(@Param() paramsDto: <<Model pascal>>DeleteParamsDto): Promise<<<Model pascal>>> {
+  public delete(@Param() paramsDto: <<Model pascal>>DeleteParamsDto) {
     const formatedParams = this.<<Model camel>>RestDtoService.formatDeleteDto(paramsDto);
     return this.<<Model camel>>Service.delete(formatedParams);
   }

--- a/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
+++ b/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
@@ -46,7 +46,7 @@ export class <<Model pascal>>Controller {
    * @returns a new User
    */
   @Post()
-  public async create(@Body() bodyDto: <<Model pascal>>CreateBodyDto): Promise<<<Model pascal>>> {
+  public create(@Body() bodyDto: <<Model pascal>>CreateBodyDto): Promise<<<Model pascal>>> {
     const formatedParams = this.<<Model camel>>RestDtoService.formatCreateDto(bodyDto);
     return this.<<Model camel>>Service.create(formatedParams);
   }
@@ -71,7 +71,7 @@ export class <<Model pascal>>Controller {
    * @returns a User or null
    */
   @Get(':id')
-  public async findUnique(
+  public findUnique(
     @Param() paramsDto: <<Model pascal>>FindUniqueParamsDto,
     <<<if (root.dependencies.list.length || root.referencedIn.length) {>>>
     @Query() queryDto: <<Model pascal>>FindUniqueQueryDto,
@@ -93,7 +93,7 @@ export class <<Model pascal>>Controller {
    * @returns an array of <<Model pascal>> entities
    */
   @Get()
-  public async findMany(
+  public findMany(
     @Query() queryDto: <<Model pascal>>FindManyQueryDto,
   ): Promise<<<Model pascal>>[]> {
     const formatedParams = this.<<Model camel>>RestDtoService.formatFindManyDto(queryDto);
@@ -112,7 +112,7 @@ export class <<Model pascal>>Controller {
    * @returns the updated <<Model pascal>>
    */
   @Patch(':id')
-  public async update(
+  public update(
     @Param() paramsDto: <<Model pascal>>UpdateParamsDto,
     @Body() bodyDto: <<Model pascal>>UpdateBodyDto,
   ): Promise<<<Model pascal>>> {
@@ -136,7 +136,7 @@ export class <<Model pascal>>Controller {
    * @returns the updated <<Model pascal>>
    */
   @Put(':id')
-  public async upsert(
+  public upsert(
     @Param() paramsDto: <<Model pascal>>UpsertParamsDto,
     @Body() bodyDto: <<Model pascal>>UpsertBodyDto,
   ): Promise<<<Model pascal>>> {
@@ -154,7 +154,7 @@ export class <<Model pascal>>Controller {
    * @returns the updated <<Model pascal>>
    */
   @Delete(':id')
-  public async delete(@Param() paramsDto: <<Model pascal>>DeleteParamsDto): Promise<<<Model pascal>>> {
+  public delete(@Param() paramsDto: <<Model pascal>>DeleteParamsDto): Promise<<<Model pascal>>> {
     const formatedParams = this.<<Model camel>>RestDtoService.formatDeleteDto(paramsDto);
     return this.<<Model camel>>Service.delete(formatedParams);
   }

--- a/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
+++ b/packages/hapify-templates-nestjs-models-rest/hapify/generated/nestjs-models-rest/src/__kebab__/controllers/__kebab__.controller.ts.hpf
@@ -51,6 +51,7 @@ export class <<Model pascal>>Controller {
     return this.<<Model camel>>Service.create(formatedParams);
   }
  
+<<<<<<< HEAD
   /**
   * Count the number of <<Model pascal>> entities that matches the filter
   *
@@ -63,6 +64,8 @@ export class <<Model pascal>>Controller {
     return this.<<Model camel>>Service.count(formatedParams);
   }
  
+=======
+>>>>>>> style: put back spaces on empty lines
   /**
    * Find zero or one <<Model pascal>> that matches the filter
    *
@@ -100,6 +103,21 @@ export class <<Model pascal>>Controller {
     return this.<<Model camel>>Service.findMany(formatedParams);
   }
  
+<<<<<<< HEAD
+=======
+  /**
+   * Count the number of <<Model pascal>> entities that matches the filter
+   *
+   * @param queryDto - Dto of the request query
+   * @returns the number of <<Model pascal>>
+   */
+  @Get('count')
+  public count(@Query() queryDto: <<Model pascal>>CountQueryDto): Promise<number> {
+    const formatedParams = this.<<Model camel>>RestDtoService.formatCountDto(queryDto);
+    return this.<<Model camel>>Service.count(formatedParams);
+  }
+ 
+>>>>>>> style: put back spaces on empty lines
   /**
    * Update one <<Model pascal>>
    *


### PR DESCRIPTION
Issue #83: Remove useless `async` keywords as well as `Promise` return types in controllers methods.
Had to disable build command in package.json inside @angular-tools to be able to run build command.