### PR TITLE
fix: use import type when declaring dtos to avoid circular dependencies

### DIFF
--- a/packages/hapify-templates-models/hapify/generated/models/models/__kebab__.ts.hpf
+++ b/packages/hapify-templates-models/hapify/generated/models/models/__kebab__.ts.hpf
@@ -47,7 +47,7 @@ import {
 } from 'class-validator';
   
 <<<for (const relation of getRelations()) {>>>
-import { <<relation pascal>> } from './<<relation kebab>>';
+import type { <<relation pascal>> } from './<<relation kebab>>';
 <<<}>>>
  
 <<if Fields enum>>


### PR DESCRIPTION
Closes #113 