### PR TITLE
fix(react-admin): fix: make object field input work on react admin

### DIFF
--- a/libs/hapify/templates/react-admin/hapify/generated/react-admin/resources/__pascal__/Write.tsx.hpf
+++ b/libs/hapify/templates/react-admin/hapify/generated/react-admin/resources/__pascal__/Write.tsx.hpf
@@ -128,6 +128,10 @@ export const <<Model pascal>>Edit = (props: EditProps) => (
         sx={{
           width: '100%',
         }}
+         <<if field object>>
+        parse={(v) => JSON.parse(v || null)}
+        format={(v) => JSON.stringify(v || undefined)}
+        <<endif>>
 <<endif>>
 
     <<if field not nullable>>


### PR DESCRIPTION
Object field wasn't working on react admin. They wasn't format before show on text field and they wasn't parsed before send to backend.